### PR TITLE
Account for Flow annotations in react/sort-comp

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -290,7 +290,15 @@ module.exports = {
     'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'error',
     'react/self-closing-comp': 'error',
-    'react/sort-comp': 'error',
+    'react/sort-comp': ['error', {
+      order: [
+        'type-annotations',
+        'static-methods',
+        'lifecycle',
+        'everything-else',
+        'render'
+      ]
+    }],
 
     'jsx-a11y/img-has-alt': 'error',
     'jsx-a11y/img-redundant-alt': 'error',

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-umbrellio",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ESLint config for Umbrellio javascript code style",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
When using Flow prop type annotations instead of vanilla React `propTypes`, default `react/sort-comp` configuration treats them as "anything else". With this change, Flow type annotations will be treated as a separate entity.

**Before**:

```js
/* @flow */
class MyComponent extends React.Component {
  componentDidMount () { /*...*/ }
  props: {
    title: string
  }
}
```

**After**:

```js
/* @flow */
class MyComponent extends React.Component {
  props: {
    title: string
  }
  componentDidMount () { /*...*/ }
}
```