### PR TITLE
Allow parens in eslint/no-confusing-arrow (+ object-curly-spacing)

### DIFF
--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-umbrellio",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ESLint config for Umbrellio javascript code style",
   "main": "index.js",
   "keywords": [

--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -196,6 +196,9 @@ rules:
   no-useless-return: error
   no-whitespace-before-property: error
   no-with: error
+  object-curly-spacing:
+    - error
+    - always
   object-property-newline:
     - error
     - allowMultiplePropertiesPerLine: true

--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -73,7 +73,9 @@ rules:
   no-caller: error
   no-class-assign: error
   no-cond-assign: error
-  no-confusing-arrow: error
+  no-confusing-arrow:
+    - error
+    - allowParens: true
   no-const-assign: error
   no-constant-condition:
     - error


### PR DESCRIPTION
Before:
```js
// bad
const fn = x => x ? 0 : 1
// bad
const fn = x => (x ? 0 : 1)
// good
const fn = (x) => { return x ? 0 : 1 }
```

After:
```js
// bad
const fn = x => x ? 0 : 1
// good
const fn = x => (x ? 0 : 1)
```