### PR TITLE
[Rubocop] disabled Style/SymbolArray

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -65,10 +65,3 @@ Style/ClassAndModuleChildren:
 Style/HashSyntax:
   Exclude:
     - lib/**/tasks/**/*
-
-Style/SymbolArray:
-  Exclude:
-    - apps/**/*controller.rb
-    - spec/**/*controller_spec.rb
-    - config/routes.rb
-    - db/migrate/**/*

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -194,10 +194,6 @@ Style/StringLiteralsInInterpolation:
 Style/SpaceInsideBrackets:
   Enabled: false
 
-Style/SymbolArray:
-  # Disabled by default
-  Enabled: true
-
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
This cop sucks in situations where array could either be symbol or mixed because it breaks consistency