### PR TITLE
Change linter behavior with parentheses in lambda params

### DIFF
--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -1,5 +1,8 @@
 rules:
   accessor-pairs: error
+  allow-parens:
+    - as-needed
+    - requireForBlockBody: false
   array-callback-return: error
   arrow-spacing:
     - error

--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -1,8 +1,5 @@
 rules:
   accessor-pairs: error
-  allow-parens:
-    - as-needed
-    - requireForBlockBody: false
   array-callback-return: error
   arrow-spacing:
     - error

--- a/eslint/rules/etc.yml
+++ b/eslint/rules/etc.yml
@@ -2,7 +2,7 @@ rules:
   curry/arrow-parens:
     - error
     - as-needed
-    - requireForBlockBody: true
+    - requireForBlockBody: false
       curry: never
 
   prefer-object-spread/prefer-object-spread: error


### PR DESCRIPTION
Right now
```
fetch(url).then(data => {
   ...
})
```
won't pass linter being forced to place parentheses around `data`.
Proposed change will relax this restriction.