### PR TITLE
Disable "import/prefer-default-export"

### DIFF
--- a/eslint/rules/import.yml
+++ b/eslint/rules/import.yml
@@ -5,4 +5,4 @@ rules:
   import/no-duplicates: error
   import/no-mutable-exports: error
   import/no-webpack-loader-syntax: error
-  import/prefer-default-export: error
+  import/prefer-default-export: off


### PR DESCRIPTION
This rule doesn't allow to have a file with a single named (non-default) export. I think single named exports should be allowed because "named vs default exports" should be determined by module's semantics, not the number of exports.