### PR TITLE
Disable "newline-per-chained-call"

### DIFF
--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -64,7 +64,7 @@ rules:
     - 100
   new-cap: error
   new-parens: error
-  newline-per-chained-call: error
+  newline-per-chained-call: off
   no-array-constructor: error
   no-caller: error
   no-class-assign: error


### PR DESCRIPTION
Before:
```js
// bad
d3.select("body").selectAll("p").style("color", "blue")
// good
d3
  .select("body")
  .selectAll("p")
  .style("color", "blue")
```

I think this style of writing code should not be enforced so strictly. Sometimes the first looks better. I propose we disable this rule.

Also: this conflicts with [prettier](https://github.com/prettier/prettier).