### PR TITLE
[Rubocop] fixed config for Metrics/MethodLength

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -16,7 +16,9 @@ Metrics/LineLength:
     - lib/**/tasks/**/*
 
 Metrics/MethodLength:
-  Exclude: db/**/*
+  Exclude:
+    - db/**/*
+    - config/initializers/**/*
 
 # Rails
 

--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -6,12 +6,12 @@ inherit_gem:
 Metrics/BlockLength:
   # TODO: use 'ExcludedMethods' config which is more selective
   Exclude:
+    - config/initializers/**/*
     - config/routes.rb
     - spec/**/*
 
 Metrics/LineLength:
   Exclude:
-    - config/initializers/*
     - config/environments/*
     - lib/**/tasks/**/*
 

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -74,7 +74,7 @@ RSpec/LetSetup:
   Enabled: false
 
 RSpec/MessageSpies:
-  EnforcedStyle: receive
+  Enabled: false
 
 RSpec/MultipleDescribes:
   Enabled: false

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   # x.y.z.t
   # Where x.y.z = rubocop version
   # t is incremental
-  spec.version = "0.48.1.3"
+  spec.version = "0.48.1.4"
   spec.authors = ["JelF"]
   spec.email = ["begdory4@gmail.com"]
 


### PR DESCRIPTION
- fixed config for etrics/MethodLength

- excluded config/initializers/**/* in  Metrics/BlockLength

- disabled RSpec/MessageSpies
  Maybe enable some day later with EnforcedStyle: have_received