### PR TITLE
[Rubocop] updated to rubocop-0.49.1

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -26,12 +26,11 @@ Rails:
   Enabled: true
 
 Rails/ApplicationJob:
-  # Projects which have ApplciationJob abstraction should enable it localy
-  Enabled: false
+  Enabled: true
 
 Rails/ApplicationRecord:
-  # Projects which have ApplciationRecord abstraction should enable it localy
-  Enabled: false
+  # Use it even you use Sequel
+  Enabled: true
 
 Rails/Delegate:
   Enabled: false

--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -25,6 +25,12 @@ Metrics/MethodLength:
 Rails:
   Enabled: true
 
+Rails/ApplicationJob:
+  Enabled: false
+
+Rails/ApplicationRecord:
+  Enabled: false
+
 Rails/Delegate:
   Enabled: false
 

--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -26,9 +26,11 @@ Rails:
   Enabled: true
 
 Rails/ApplicationJob:
+  # Projects which have ApplciationJob abstraction should enable it localy
   Enabled: false
 
 Rails/ApplicationRecord:
+  # Projects which have ApplciationRecord abstraction should enable it localy
   Enabled: false
 
 Rails/Delegate:

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -187,7 +187,12 @@ Style/MultilineTernaryOperator:
   Enabled: false
 
 Style/MultipleComparison:
-  # foo.in? %w[bar baz] instead of foo == 'bar' || foo == 'baz'
+  # Bad
+  # if foo == 1 || foo == 2
+  # Good
+  # [1, 2].include?(foo)
+  # With activesupport, this is better
+  # foo.in? [1, 2]
   Enabled: true
 
 Style/NumericLiterals:

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -98,6 +98,9 @@ RSpec/DescribedClass:
 RSpec/DescribeMethod:
   Enabled: false
 
+RSpec/FilePath:
+  Enabled: false
+
 RSpec/LetSetup:
   Enabled: false
 

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -4,7 +4,24 @@ AllCops:
   Exclude:
     - bin/**/*
 
-# LINT
+# Layout
+
+Layout/AlignParameters:
+  Enabled: true
+
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_space
+
+Layout/SpaceInsideBrackets:
+  Enabled: false
+
+# Lint
 
 Lint/AmbiguousBlockAssociation:
   # `scope :name, -> (param) { ... }` is a valid syntax
@@ -19,8 +36,16 @@ Lint/NonLocalExitFromIterator:
 Lint/HandleExceptions:
   Enabled: false
 
+Lint/RescueType:
+  # It's generally useless, but why not?
+  Enabled: true
+
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
+
+Lint/ScriptPermission:
+  # checks +x on scripts
+  Enabled: true
 
 # Metrics
 
@@ -49,6 +74,9 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 # Performance
+
+Performance/Caller:
+  Enabled: true
 
 Performance/Casecmp:
   Enabled: false
@@ -97,9 +125,6 @@ Style/AccessorMethodName:
   # This cop assumes every method is accessor
   Enabled: false
 
-Style/AlignParameters:
-  Enabled: true
-
 Style/AndOr:
   # `do_something and return`
   Enabled: false
@@ -131,6 +156,10 @@ Style/EmptyElse:
 Style/Encoding:
   Enabled: false
 
+Style/FormatStringToken:
+  # TODO: i did not test that, should test before relase
+  Enabled: true
+
 Style/IfUnlessModifier:
   Enabled: true
 
@@ -143,14 +172,12 @@ Style/LambdaCall:
 Style/ModuleFunction:
   Enabled: false
 
-Style/MultilineMethodCallIndentation:
-  Enabled: false
-
-Style/MultilineOperationIndentation:
-  Enabled: false
-
 Style/MultilineTernaryOperator:
   Enabled: false
+
+Style/MultipleComparison:
+  # foo.in? %w[bar baz] instead of foo == 'bar' || foo == 'baz'
+  Enabled: true
 
 Style/NumericLiterals:
   Description: 'Use indent in groups of 3 unlesss you meet project-specific rule'
@@ -179,8 +206,6 @@ Style/RegexpLiteral:
 Style/RescueModifier:
   Enabled: false
 
-Style/SpaceInLambdaLiteral:
-  EnforcedStyle: require_space
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -195,9 +220,6 @@ Style/SingleLineBlockParams:
 Style/StringLiteralsInInterpolation:
   Enabled: false
 
-Style/SpaceInsideBrackets:
-  Enabled: false
-
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
@@ -206,4 +228,8 @@ Style/TrailingCommaInLiteral:
 
 Style/TrivialAccessors:
   AllowPredicates: true
+  Enabled: false
+
+Style/YodaCondition:
+  # REVIEW: i sure that we don't need it
   Enabled: false

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -10,7 +10,7 @@ Layout/AlignParameters:
   Enabled: true
 
 Layout/MultilineMethodCallIndentation:
-  Enabled: false
+  Enabled: true
 
 Layout/MultilineOperationIndentation:
   Enabled: false
@@ -157,7 +157,15 @@ Style/Encoding:
   Enabled: false
 
 Style/FormatStringToken:
-  # TODO: i did not test that, should test before relase
+  # Bad
+  # [7] pry(main)> format "%{foo}", foo: 123
+  # => "123"
+  # Good
+  # [8] pry(main)> format "%<foo>s", foo: 123
+  # => "123"
+  # Also good
+  # [9] pry(main)> format "%<foo>f", foo: 123
+  # => "123.000000"
   Enabled: true
 
 Style/IfUnlessModifier:

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   # x.y.z.t
   # Where x.y.z = rubocop version
   # t is incremental
-  spec.version = "0.48.1.4"
+  spec.version = "0.49.1.0"
   spec.authors = ["JelF"]
   spec.email = ["begdory4@gmail.com"]
 
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/umbrellio/code-style"
   spec.files = Dir["lib/rubocop.*.yml"] << "lib/rubocop.yml"
 
-  spec.add_dependency "rubocop", "= 0.48.1"
-  spec.add_dependency "rubocop-rspec", "= 1.15.0"
+  spec.add_dependency "rubocop", "= 0.49.1"
+  spec.add_dependency "rubocop-rspec", "= 1.15.1"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
* New cops Rails/ApplicationJob and Rails/ApplicationRecord
It requires some support in code base, but always a good idea

* AlignParameters, MultilineMethodCallIndentation, MultilineOperationIndentation, SpaceInLambdaLiteral and SpaceInsideBrackets cops moved From Style/ to Layout/

* Enabled Layout/MultilineMethodCallIndentation
Most violations of this cop i found in our ode were awfull

* New cops Lint/RescueType and Lint/ScriptPermission
They are good and we had no violations

* New cop Performance/Caller
It's ruby 2.* today

* Finnaly disabled RSpec/FilePath
Rubocop fixed a bug when it could not be disabled

* New cop Style/FormatStringToken
Experimental. `%{}` is suggested by very much of guides, but `%<>s` seems better. At least, that guides never told about `%<>s`

* New cop Style/MultipleComparison
It suggest Array#include?, but we can use `Object#in?` in rails projects. Only one violation found!

* Disabled new cop Style/YodaCondition
This is not cop you are looking for
