### PR TITLE
[ESLint] Remove eslint-plugin-curry

### DIFF
--- a/eslint/CHANGELOG.md
+++ b/eslint/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.2] - 2017-06-06
+### Removed
+- `eslint-plugin-curry`
+
 ## [0.4.1] - 2017-06-06
 ### Changed
 - Added `ForInStatement` to `no-restricted-syntax` rule.

--- a/eslint/README.md
+++ b/eslint/README.md
@@ -10,7 +10,7 @@ yarn add -D eslint-config-umbrellio
 Install peer dependencies if you already haven't:
 
 ```
-yarn add -D eslint-plugin-import eslint-plugin-node eslint-plugin-prefer-object-spread eslint-plugin-promise eslint-plugin-curry
+yarn add -D eslint-plugin-import eslint-plugin-node eslint-plugin-prefer-object-spread eslint-plugin-promise
 ```
 
 Add `umbrellio` to "extends" section of ESLint config:

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  plugins: ['curry', 'import', 'node', 'prefer-object-spread', 'promise'],
+  plugins: ['import', 'node', 'prefer-object-spread', 'promise'],
   extends: ['./rules/es6', './rules/etc', './rules/import'].map(require.resolve),
 }

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-umbrellio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "ESLint config for Umbrellio javascript code style",
   "main": "index.js",
   "keywords": [
@@ -13,7 +13,6 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-curry": "^0.1.0",
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jest": "^20.0.1",

--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -1,6 +1,9 @@
 rules:
   accessor-pairs: error
   array-callback-return: error
+  arrow-parens:
+    - error
+    - as-needed
   arrow-spacing:
     - error
     - before: true

--- a/eslint/rules/etc.yml
+++ b/eslint/rules/etc.yml
@@ -1,10 +1,4 @@
 rules:
-  curry/arrow-parens:
-    - error
-    - as-needed
-    - requireForBlockBody: false
-      curry: never
-
   prefer-object-spread/prefer-object-spread: error
 
   node/no-deprecated-api: error


### PR DESCRIPTION
Since we're already preferring not to use brackets around single arrow function arguments in all cases, we no longer require `eslint-plugin-curry`.