### PR TITLE
[Rubocop] Disabled `Rails/SkipsModelValidations`

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -53,20 +53,7 @@ Rails/SaveBang:
   Enabled: true
 
 Rails/SkipsModelValidations:
-  Enabled: true
-  Blacklist:
-    - decrement!
-    - decrement_counter
-    - increment!
-    - increment_counter
-    - toggle!
-    - touch
-    # allow update_all
-    # - update_all
-    - update_attribute
-    - update_column
-    - update_columns
-    - update_counters
+  Enabled: false
 
 # Style
 


### PR DESCRIPTION
In specs, there are reasons to skip validations and accessors. E.g. tests for incosistent database state