### PR TITLE
[ESLint] Add a separate 'browser' config

### DIFF
--- a/eslint/.eslintrc.json
+++ b/eslint/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "./index.js",
+    "./browser.js",
     "./flow.js",
     "./jest.js",
     "./react.js"

--- a/eslint/CHANGELOG.md
+++ b/eslint/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## master
+### Added
+- Separate browser config.
+
 ## [0.4.3] - 2017-06-08
 ### Changed
 - Changed `quotes` and `jsx-quotes` rules to `double`.

--- a/eslint/README.md
+++ b/eslint/README.md
@@ -27,6 +27,7 @@ You can also enable optional configs:
 {
   "extends": [
     "umbrellio",
+    "umbrellio/browser",
     "umbrellio/flow",
     "umbrellio/react",
     "umbrellio/jest"

--- a/eslint/browser.js
+++ b/eslint/browser.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["./rules/browser"].map(require.resolve),
+  env: {
+    browser: true,
+  },
+}

--- a/eslint/flow.js
+++ b/eslint/flow.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['flowtype'],
-  extends: ['./rules/flowtype'].map(require.resolve),
+  plugins: ["flowtype"],
+  extends: ["./rules/flowtype"].map(require.resolve),
 }
 

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  plugins: ['import', 'node', 'prefer-object-spread', 'promise'],
-  extends: ['./rules/es6', './rules/etc', './rules/import'].map(require.resolve),
+  plugins: ["import", "node", "prefer-object-spread", "promise"],
+  extends: ["./rules/es6", "./rules/etc", "./rules/import"].map(require.resolve),
 }

--- a/eslint/jest.js
+++ b/eslint/jest.js
@@ -1,4 +1,4 @@
 module.exports = {
-  plugins: ['jest'],
-  extends: ['./rules/jest'].map(require.resolve),
+  plugins: ["jest"],
+  extends: ["./rules/jest"].map(require.resolve),
 }

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ['react', 'jsx-a11y'],
-  extends: ['./rules/react'].map(require.resolve),
+  plugins: ["react", "jsx-a11y"],
+  extends: ["./rules/react"].map(require.resolve),
 }
 

--- a/eslint/rules/browser.yml
+++ b/eslint/rules/browser.yml
@@ -1,0 +1,4 @@
+rules:
+  no-restricted-globals:
+    - error
+    - event


### PR DESCRIPTION
We need to make a separate config for browser environment.
For example, [`event` global](https://developer.mozilla.org/en/docs/Web/API/Window/event) should be restricted.
Bonus: double quotes.