### PR TITLE
[ESLint] Enable 'props: true' for 'no-param-reassign'

### DIFF
--- a/eslint/CHANGELOG.md
+++ b/eslint/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## master
 ### Added
 - Separate browser config.
+### Changed
+- Set `props` to `true` for `no-param-reassign` rule.
 
 ## [0.4.3] - 2017-06-08
 ### Changed

--- a/eslint/rules/es6.yml
+++ b/eslint/rules/es6.yml
@@ -139,7 +139,9 @@ rules:
   no-obj-calls: error
   no-octal: error
   no-octal-escape: error
-  no-param-reassign: error
+  no-param-reassign:
+    - error
+    - props: true
   no-path-concat: error
   no-plusplus: error
   no-proto: error


### PR DESCRIPTION
Most of the benefits of `no-params-reassign` rule come when `props: true` is set.