### PR TITLE
change react/jsx-wrap-multilines

### DIFF
--- a/eslint/CHANGELOG.md
+++ b/eslint/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.5] - 2017-07-25
+### Changed
+- Set `arrow` to `false` for `react/jsx-wrap-multilines` rule.
+
 ## [0.4.4] - 2017-06-23
 ### Added
 - Set `error` for `no-alert` and `no-console` rules.

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-umbrellio",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "ESLint config for Umbrellio javascript code style",
   "main": "index.js",
   "keywords": [

--- a/eslint/rules/react.yml
+++ b/eslint/rules/react.yml
@@ -32,7 +32,12 @@ rules:
       afterOpening: never
   react/jsx-uses-react: error
   react/jsx-uses-vars: error
-  react/jsx-wrap-multilines: error
+  react/jsx-wrap-multilines:
+    - error
+    - declaration: true
+      assignment: true
+      return: true
+      arrow: false
   react/no-did-update-set-state: error
   react/no-is-mounted: error
   react/no-string-refs: error


### PR DESCRIPTION
```
const Header = () =>
  <div id="header">
    <h1><img src={icon} id="icon" /></h1>
  </div>
```
better than 
```
const Header = () =>
  (<div id="header">
    <h1><img src={icon} id="icon" /></h1>
  </div>)
``` 