### PR TITLE
[Rubocop] Fix bug with Metrics/BlockLength disabling

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -3,9 +3,6 @@ inherit_gem:
 
 # Metrics
 
-Metrics/BlockLength:
-  Enabled: false
-
 Metrics/LineLength:
   Exclude:
     - config/environments/*

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -83,8 +83,7 @@ Metrics/AbcSize:
   Enabled: false
 
 Metrics/BlockLength:
-  Exclude:
-    - spec/**/*
+  Enabled: false
 
 Metrics/ClassLength:
   Enabled: false

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   # x.y.z.t
   # Where x.y.z = rubocop version
   # t is incremental
-  spec.version = "0.49.1.5"
+  spec.version = "0.49.1.6"
   spec.authors = ["JelF"]
   spec.email = ["begdory4@gmail.com"]
 


### PR DESCRIPTION
Due to mistake, it previously was disabled in rubocop.rails.yml