### PR TITLE
[Rubocop] 0.50.0 update

### DIFF
--- a/rubocop/lib/rubocop.rails.yml
+++ b/rubocop/lib/rubocop.rails.yml
@@ -31,6 +31,9 @@ Rails/Delegate:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
 Rails/HttpPositionalArguments:
   # rails 5 feature https://github.com/bbatsov/rubocop/issues/3629
   Enabled: false

--- a/rubocop/lib/rubocop.rspec.yml
+++ b/rubocop/lib/rubocop.rspec.yml
@@ -1,6 +1,34 @@
 require: rubocop-rspec
 
+AllCops:
+  RSpec/FactoryGirl:
+    Patterns:
+      - spec/factories.rb
+      - spec/factories/**/*.rb
+      - features/support/factories/**/*.rb
+
+# Capybara
+
+Capybara/CurrentPathExpectation:
+  Enabled: true
+
+Capybara/FeatureMethods:
+  Enabled: false
+
+# FactoryGirl
+
+FactoryGirl/DynamicAttributeDefinedStatically:
+  Enabled: true
+
 # RSpec
+
+RSpec/AlignLeftLetBrace:
+  # Never do it
+  Enabled: false
+
+RSpec/AlignRightLetBrace:
+  # Never do it
+  Enabled: false
 
 RSpec/AnyInstance:
   Enabled: false
@@ -19,8 +47,18 @@ RSpec/DescribedClass:
 RSpec/DescribeMethod:
   Enabled: false
 
+RSpec/ExpectInHook:
+  # try not to use expect in before / after / around blocks anyway
+  Enabled: false
+
 RSpec/FilePath:
   Enabled: false
+
+RSpec/InvalidPredicateMatcher:
+  Enabled: true
+
+RSpec/LetBeforeExamples:
+  Enabled: true
 
 RSpec/LetSetup:
   Enabled: false
@@ -37,7 +75,23 @@ RSpec/MultipleDescribes:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleSubjects:
+  Enabled: true
+
 RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/ReturnFromStub:
+  # expect(foo).to receive(:bar) { :baz } # Bad
+  # expect(foo).to receive(:bar).and_return(:baz) # Good
+  # expect(foo).to receive(:bar).and_return { Time.current } # Good
+  Enabled: true
+
+RSpec/PredicateMatcher:
+  # Predicate matchers' error messages are shitty, we should not use them unless they aren't
+  # expect(foo).to be_nil # good
+  # expect(foo).to be_active # bad if foo.inspect takes 5 screens
+  # expect(foo.active?).to be_truthy # good
   Enabled: false
 
 RSpec/ScatteredSetup:
@@ -45,3 +99,6 @@ RSpec/ScatteredSetup:
 
 RSpec/VerifiedDoubles:
   Enabled: false
+
+RSpec/VoidExpect:
+  Enabled: true

--- a/rubocop/lib/rubocop.rspec.yml
+++ b/rubocop/lib/rubocop.rspec.yml
@@ -1,0 +1,47 @@
+require: rubocop-rspec
+
+# RSpec
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 20
+  Exclude:
+    - spec/features/**/*
+
+RSpec/DescribeClass:
+  Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+RSpec/DescribeMethod:
+  Enabled: false
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/MessageChain:
+  Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/MultipleDescribes:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/ScatteredSetup:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -10,19 +10,6 @@ AllCops:
 Layout/AlignParameters:
   Enabled: true
 
-Layout/MultilineMethodCallIndentation:
-  # We don't like this cop
-  Enabled: false
-
-Layout/MultilineOperationIndentation:
-  Enabled: false
-
-Layout/SpaceInLambdaLiteral:
-  EnforcedStyle: require_space
-
-Layout/SpaceInsideBrackets:
-  Enabled: false
-
 Layout/IndentArray:
   # Good
   # foo([
@@ -38,6 +25,19 @@ Layout/IndentArray:
 
 Layout/IndentHash:
   EnforcedStyle: consistent
+
+Layout/MultilineMethodCallIndentation:
+  # We don't like this cop
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_space
+
+Layout/SpaceInsideBrackets:
+  Enabled: false
 
 # Lint
 
@@ -69,6 +69,10 @@ Lint/HandleExceptions:
 Lint/RescueType:
   # It's generally useless, but why not?
   Enabled: true
+
+Lint/RescueWithoutErrorClass:
+  # We forced `rescue` over `rescue StandardError`
+  Enabled: false
 
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
@@ -103,6 +107,17 @@ Metrics/MethodLength:
 
 Metrics/PerceivedComplexity:
   Enabled: false
+
+# Naming
+
+Naming/AccessorMethodName:
+  # This cop assumes every method is accessor
+  Enabled: false
+
+Naming/PredicateName:
+  # `has_` is generally good
+  NamePrefixBlacklist:
+    - is_
 
 # Performance
 
@@ -158,16 +173,17 @@ RSpec/ScatteredSetup:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+# Performance
+
+Performance/UnfreezeString:
+  Enabled: true
+
 # Security
 
 Security/YAMLLoad:
   Enabled: false
 
 # Style
-
-Style/AccessorMethodName:
-  # This cop assumes every method is accessor
-  Enabled: false
 
 Style/AndOr:
   # `do_something and return`
@@ -183,6 +199,9 @@ Style/CommentAnnotation:
 
 Style/ConditionalAssignment:
   Enabled: false
+
+Style/Dir:
+  Enabled: true
 
 Style/Documentation:
   Enabled: false
@@ -247,14 +266,12 @@ Style/PerlBackrefs:
   # Disable localy if realy neeeded
   Enabled: true
 
-Style/PredicateName:
-  # `has_` is generally good
-  NamePrefixBlacklist:
-    - is_
-
 Style/RaiseArgs:
   Description: 'Use `raise, ErrorClass` in all cases but not when you need ErrorClass constructor'
   Enabled: false
+
+Style/RedundantConditional:
+  Enabled: true
 
 Style/RegexpLiteral:
   EnforcedStyle: mixed
@@ -262,7 +279,6 @@ Style/RegexpLiteral:
 
 Style/RescueModifier:
   Enabled: false
-
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rspec
+inherit_gem:
+  rubocop-config-umbrellio: lib/rubocop.rspec.yml
 
 AllCops:
   Exclude:
@@ -125,52 +126,6 @@ Performance/Caller:
   Enabled: true
 
 Performance/Casecmp:
-  Enabled: false
-
-# RSpec
-
-RSpec/AnyInstance:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Max: 20
-  Exclude:
-    - spec/features/**/*
-
-RSpec/DescribeClass:
-  Enabled: false
-
-RSpec/DescribedClass:
-  Enabled: false
-
-RSpec/DescribeMethod:
-  Enabled: false
-
-RSpec/FilePath:
-  Enabled: false
-
-RSpec/LetSetup:
-  Enabled: false
-
-RSpec/MessageChain:
-  Enabled: false
-
-RSpec/MessageSpies:
-  Enabled: false
-
-RSpec/MultipleDescribes:
-  Enabled: false
-
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/NestedGroups:
-  Enabled: false
-
-RSpec/ScatteredSetup:
-  Enabled: false
-
-RSpec/VerifiedDoubles:
   Enabled: false
 
 # Performance

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   # x.y.z.t
   # Where x.y.z = rubocop version
   # t is incremental
-  spec.version = "0.49.1.6"
+  spec.version = "0.50.0.0"
   spec.authors = ["JelF"]
   spec.email = ["begdory4@gmail.com"]
 
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/umbrellio/code-style"
   spec.files = Dir["lib/rubocop.*.yml"] << "lib/rubocop.yml"
 
-  spec.add_dependency "rubocop", "= 0.49.1"
+  spec.add_dependency "rubocop", "= 0.50.0"
   spec.add_dependency "rubocop-rspec", "= 1.15.1"
 
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/rubocop.*.yml"] << "lib/rubocop.yml"
 
   spec.add_dependency "rubocop", "= 0.50.0"
-  spec.add_dependency "rubocop-rspec", "= 1.15.1"
+  spec.add_dependency "rubocop-rspec", "= 1.18.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
- **moved rspec config to separate file**

- **updated rubocop to 0.50.0** (https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#0500-2017-09-14)

- Lint/DuplicateMethods now uderstands attr_* methods and aliases.
  **Mass violations found** ☹

- new cop Style/RedundantConditional is good.
  And we have no violaions!

- new cop Rails/HasManyOrHasOneDependent is scary
  Disabled it globaly, may be we can enable it in some projects

- new cop Style/Dir is good.
  `__dir__` seems better than `File.expand_path(File.dirname(__FILE__))`

- **new cop Lint/RescueWithoutErrorClass** could be good.
  However, we forced `rescue` instead of `rescue StandardError`.
  Disabled it for now, but maybe we will force it instead?

- new cop Performance/UnfreezeString forces `+""`
  instead of `String.new`. It's cool

- **updated rubocop-rspec to 1.18.0** (https://github.com/backus/rubocop-rspec/blob/master/CHANGELOG.md#1180-2017-09-29)

- new cop FactoryGirl/DynamicAttributeDefinedStatically is good.
  Mass violations in code! Real shit because all of them are bugs.
  Enabled it

- new cops RSpec/Align{Left,Right}LetBrace force antipattern.
  Disabled them (which is default)

- **new cop RSpec/LetBeforeExamples** is good.
  I consider it quite useful, but we may need a discussion.
  Enabled it

- new cop RSpec/MultipleSubjects is good.
  Enabled it

- new cop RSpec/ReturnFromStub is good.
  We have mass violations, but it should not be a problem. It's only
  about style. Enabled it

- new cop RSpec/VoidExpect is good.
  We had violations in past and they always were errors. Enabled it

- new cop RSpec/PredicateMatcher is damned.
  Predicate matchers' error messages are shitty, we should not use them

- new cop RSpec/InvalidPredicateMatcher.
  Haven't found any offences so enabled it. No idea what does it do

- new cop RSpec/ExpectInHook is good.
  But it is too good for us. Disabled

- **new cop Capybara/FeatureMethods** is strange.
  Disabled it beacause `scenario` and `it` means different things

- new cop Capybara/CurrentPathExpectation.
  They should have a reason to make it.
  Enabled it due to zero violations in our code