### PR TITLE
Disable useless AsciiComments rule

### DIFF
--- a/rubocop/lib/rubocop.yml
+++ b/rubocop/lib/rubocop.yml
@@ -143,6 +143,9 @@ Security/YAMLLoad:
 
 # Style
 
+Style/AsciiComments:
+  Enabled: false
+
 Style/AndOr:
   # `do_something and return`
   Enabled: false


### PR DESCRIPTION
Confusing rule because our comments can potentially contain data in different formats (math formulas for example)