### PR TITLE
[rubocop] upgrade rubocop/rubocop-rspec

### DIFF
--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   # x.y.z.t
   # Where x.y.z = rubocop version
   # t is incremental
-  spec.version = "0.56.0"
+  spec.version = "0.58.2"
   spec.authors = ["JelF"]
   spec.email = ["begdory4@gmail.com"]
 
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/umbrellio/code-style"
   spec.files = Dir["lib/rubocop.*.yml"] << "lib/rubocop.yml"
 
-  spec.add_dependency "rubocop", "= 0.56.0"
-  spec.add_dependency "rubocop-rspec", "= 1.25.1"
+  spec.add_dependency "rubocop", "= 0.58.2"
+  spec.add_dependency "rubocop-rspec", "= 1.27.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
- rubocop: 0.56.0 => 0.58.2
- rubocop-rspec: 1.25.1 => 1.27.0