### PR TITLE
Update rubocop

### DIFF
--- a/rubocop/Gemfile.lock
+++ b/rubocop/Gemfile.lock
@@ -1,56 +1,56 @@
 PATH
   remote: .
   specs:
-    rubocop-config-umbrellio (1.25.0)
-      rubocop (~> 1.25.0)
-      rubocop-performance (~> 1.13.0)
-      rubocop-rails (~> 2.13.0)
+    rubocop-config-umbrellio (1.30.0)
+      rubocop (~> 1.30.0)
+      rubocop-performance (~> 1.14.0)
+      rubocop-rails (~> 2.14.2)
       rubocop-rake (~> 0.6.0)
-      rubocop-rspec (~> 2.7.0)
+      rubocop-rspec (~> 2.11.1)
       rubocop-sequel (~> 0.3.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.1)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.9)
-    i18n (1.8.11)
+    concurrent-ruby (1.1.10)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     minitest (5.15.0)
-    parallel (1.21.0)
-    parser (3.1.0.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.2.0)
+    regexp_parser (2.4.0)
     rexml (3.2.5)
-    rubocop (1.25.0)
+    rubocop (1.30.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    rubocop-performance (1.13.2)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
+    rubocop-performance (1.14.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.13.2)
+    rubocop-rails (2.14.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.7.0)
+    rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     rubocop-sequel (0.3.3)
       rubocop (~> 1.0)
@@ -61,6 +61,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-20
   x86_64-linux
 
@@ -70,4 +71,4 @@ DEPENDENCIES
   rubocop-config-umbrellio!
 
 BUNDLED WITH
-   2.3.2
+   2.3.14

--- a/rubocop/lib/rubocop.rspec.yml
+++ b/rubocop/lib/rubocop.rspec.yml
@@ -102,3 +102,12 @@ RSpec/VerifiedDoubles:
 
 RSpec/VoidExpect:
   Enabled: true
+
+RSpec/BeEq:
+  Enabled: false
+
+RSpec/BeNil:
+  Enabled: false
+
+RSpec/ExpectChange:
+  Enabled: false

--- a/rubocop/rubocop.gemspec
+++ b/rubocop/rubocop.gemspec
@@ -4,8 +4,11 @@
 Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
-  rubocop_version = "1.25.0"
-  release_version = "#{rubocop_version}.#{ENV["GITHUB_RUN_NUMBER"]}" if ENV["PUBLISH_JOB"]
+  rubocop_version = "1.30.0"
+
+  if ENV.fetch("PUBLISH_JOB", nil)
+    release_version = "#{rubocop_version}.#{ENV.fetch("GITHUB_RUN_NUMBER")}"
+  end
 
   spec.name = "rubocop-config-umbrellio"
   spec.version = release_version || rubocop_version
@@ -19,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/rubocop.*.yml"] << "lib/rubocop.yml"
 
   spec.add_dependency "rubocop", "~> #{rubocop_version}"
-  spec.add_dependency "rubocop-performance", "~> 1.13.0"
-  spec.add_dependency "rubocop-rails", "~> 2.13.0"
+  spec.add_dependency "rubocop-performance", "~> 1.14.0"
+  spec.add_dependency "rubocop-rails", "~> 2.14.2"
   spec.add_dependency "rubocop-rake", "~> 0.6.0"
-  spec.add_dependency "rubocop-rspec", "~> 2.7.0"
+  spec.add_dependency "rubocop-rspec", "~> 2.11.1"
   spec.add_dependency "rubocop-sequel", "~> 0.3.3"
 
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
Выключил некоторые новые rspec копы, т.к. они имеют сомнительную ценность, при этом требуют править миллионы спеков. Типа юзай `be_nil` вместо `eq(nil)`, а в чем профит – непонятно.